### PR TITLE
Adiciona estado de log inválido

### DIFF
--- a/libs/lib_status.py
+++ b/libs/lib_status.py
@@ -1,3 +1,6 @@
+# coding=utf-8
+import datetime
+
 DATE_STATUS_QUEUE = 0
 DATE_STATUS_PARTIAL = 1
 DATE_STATUS_LOADED = 2
@@ -10,6 +13,7 @@ LOG_FILE_STATUS_PARTIAL = 1
 LOG_FILE_STATUS_LOADED = 2
 LOG_FILE_STATUS_LOADING = 9
 LOG_FILE_STATUS_FAILED = -1
+LOG_FILE_STATUS_INVALID = -9
 
 DATE_STATUS_SUM_FOR_LOADED = 2
 
@@ -26,3 +30,19 @@ def compute_date_status(logfile_status_list):
         return DATE_STATUS_PARTIAL
 
     return DATE_STATUS_QUEUE
+
+
+def is_valid_log(log_file_full_path, log_file_server, log_file_date):
+    date = datetime.datetime.strptime(log_file_date, '%Y-%m-%d')
+
+    # Situação em que arquivo com prefixo varnishncsa contém IPs anônimos
+    if 'varnishncsa' in log_file_full_path:
+        if date > datetime.datetime.strptime('2020-04-29', '%Y-%m-%d'):
+            return False
+
+    # Situação em que arquivo de servidor hiperion-apache contém IPs anônimos
+    if log_file_server == 'hiperion-apache':
+        if date > datetime.datetime.strptime('2020-04-29', '%Y-%m-%d'):
+            return False
+
+    return True

--- a/proc/load_logs.py
+++ b/proc/load_logs.py
@@ -17,8 +17,7 @@ from libs.lib_file_name import (
     FILE_GUNZIPPED_LOG_EXTENSION,
     extract_gunzipped_file_name
 )
-from libs.lib_status import LOG_FILE_STATUS_LOADING
-
+from libs.lib_status import LOG_FILE_STATUS_LOADING, LOG_FILE_STATUS_INVALID, LOG_FILE_STATUS_LOADED
 
 DIR_WORKING_LOGS = os.environ.get('DIR_WORKING_LOGS', '/app/data/working')
 DIR_SUMMARY = os.environ.get('DIR_SUMMARY', '/app/data/summary')
@@ -38,7 +37,7 @@ LOGGING_LEVEL = os.environ.get('LOGGING_LEVEL', 'INFO')
 def get_available_log_files(database_uri, collection, dir_working_logs, load_files_limit):
     files_names = set([f for f in os.listdir(dir_working_logs) if os.path.isfile(os.path.join(dir_working_logs, f))])
 
-    db_files = get_recent_log_files(database_uri, collection, ignore_loaded=True)
+    db_files = get_recent_log_files(database_uri, collection, [LOG_FILE_STATUS_LOADED, LOG_FILE_STATUS_INVALID])
     db_files_with_start_lines = set([(ef.id, ef.name, ef.date, get_lines_parsed(database_uri, ef.id)) for ef in db_files])
 
     available_lf = set()

--- a/proc/update_available_logs.py
+++ b/proc/update_available_logs.py
@@ -4,6 +4,8 @@ import logging
 import os
 import shutil
 
+from libs.lib_status import LOG_FILE_STATUS_INVALID, LOG_FILE_STATUS_LOADED
+
 from libs.lib_database import update_available_log_files, update_date_status, get_recent_log_files
 from libs.lib_file_name import FILE_GUNZIPPED_LOG_EXTENSION
 
@@ -22,7 +24,7 @@ LOGGING_LEVEL = os.environ.get('LOGGING_LEVEL', 'INFO')
 def copy_available_log_files(database_uri, collection, dir_working_logs, copy_files_limit):
     current_files = os.listdir(dir_working_logs)
 
-    recent_files = get_recent_log_files(database_uri, collection, ignore_loaded=True)
+    recent_files = get_recent_log_files(database_uri, collection, [LOG_FILE_STATUS_LOADED, LOG_FILE_STATUS_INVALID])
 
     for rf in recent_files.limit(copy_files_limit):
         rf_name_gz = rf.name + FILE_GUNZIPPED_LOG_EXTENSION


### PR DESCRIPTION
- Considera como inválido os seguintes logs:
    - De servidor hiperion-varnish com prefixo `varnishncsa` e com data após 2020-04-29
    - De servidor hiperion-apache com data após 2020-04-29

Estes logs estão com dados não utilizáveis para o contexto COUNTER/SUSHI.