### PR TITLE
Adiciona servidor dataverse na verificação de nome de arquivo válido

### DIFF
--- a/libs/lib_file_name.py
+++ b/libs/lib_file_name.py
@@ -9,6 +9,7 @@ FILE_HIPERION_NAME = 'hiperion'
 FILE_HIPERION_APACHE_NAME = 'hiperion-apache'
 FILE_HIPERION_VARNISH_NAME = 'hiperion-varnish'
 FILE_PREPRINTS_NAME = 'preprints'
+FILE_DATAVERSE_NAME = 'dataverse'
 FILE_VARNISH_NAME = 'varnish'
 FILE_INFO_UNDEFINED = ''
 FILE_SUMMARY_POSFIX_EXTENSION = '.summary.txt'
@@ -32,6 +33,9 @@ def extract_log_server_name(full_path):
         file_name = extract_file_name(full_path)
         if FILE_PREPRINTS_NAME in file_name:
             return FILE_PREPRINTS_NAME
+
+    elif FILE_DATAVERSE_NAME in full_path:
+        return FILE_DATAVERSE_NAME
 
     return FILE_INFO_UNDEFINED
 


### PR DESCRIPTION
Adiciona o termo "dataverse" no verificador de arquivos de log válidos para carga. Isso permitirá que os dados de acessos ao site data.scielo.org sejam contabilizados no Matomo, de forma automática, usando os mecanismos desenvolvidos neste repositório.