### PR TITLE
Adiciona tratamento de servidor indisponível

### DIFF
--- a/libs/lib_database.py
+++ b/libs/lib_database.py
@@ -165,6 +165,32 @@ def update_log_file_summary(database_uri, summary_file, expected_lines, log_file
     lfs.status = summary_data.get('status')
 
     lfs.idlogfile = log_file_id
+def update_log_file_summary_with_recovery_data(db_session, recovery_data):
+    try:
+        lfs = LogFileSummary()
+        lfs.total_lines = recovery_data.get('total_lines')
+        lfs.lines_parsed = recovery_data.get('lines_parsed')
+        lfs.status = recovery_data.get('status')
+        lfs.total_time = 0
+        lfs.ignored_lines_bots = 0
+        lfs.ignored_lines_filtered = 0
+        lfs.ignored_lines_http_errors = 0
+        lfs.ignored_lines_http_redirects = 0
+        lfs.ignored_lines_invalid = 0
+        lfs.ignored_lines_static_resources = 0
+        lfs.sum_imported_ignored_lines = 0
+        lfs.total_ignored_lines = 0
+        lfs.total_imported_lines = 0
+
+        lfs.idlogfile = recovery_data.get('idlogfile')
+
+        db_session.add(lfs)
+        db_session.commit()
+
+        return SUCCESSFUL_RECOVERY
+
+    except OperationalError:
+        logging.error('Can\'t update log file summary with recovery data. MySQL Server is unavailable.')
 
     db_session.add(lfs)
     db_session.commit()

--- a/libs/lib_database.py
+++ b/libs/lib_database.py
@@ -13,8 +13,12 @@ from libs.lib_status import (
 from libs.lib_summary import parse_summary
 from models.declarative import Base, DateStatus, LogFile, LogFileSummary
 from sqlalchemy import create_engine, and_
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
+
+
+CRITICAL_ERROR = -999
+SUCCESSFUL_RECOVERY = 999
 
 
 def create_tables(database_uri):

--- a/libs/lib_database.py
+++ b/libs/lib_database.py
@@ -170,3 +170,12 @@ def update_log_file_summary(database_uri, summary_file, expected_lines, log_file
     db_session.commit()
 
     return lfs.status
+def _save_recovery_data(recover_directory, log_file_id, expected_lines, parsed_lines, status):
+    logging.error('Can\'t update table log_file_summary. MySQL Server is unavailable.')
+    logging.warning('Creating recovery data for log file id %s.' % log_file_id)
+
+    if not os.path.exists(recover_directory):
+        os.makedirs(recover_directory)
+
+    with open(os.path.join(recover_directory, str(log_file_id) + '.tsv'), 'a') as f:
+        f.write('\t'.join([str(i) for i in [log_file_id, expected_lines, parsed_lines, status]]) + '\n')

--- a/proc/load_logs.py
+++ b/proc/load_logs.py
@@ -118,7 +118,7 @@ def main():
     if not os.path.exists(DIR_SUMMARY):
         os.makedirs(DIR_SUMMARY)
 
-    files = get_available_log_files(LOG_FILE_DATABASE_STRING, COLLECTION, DIR_WORKING_LOGS, LOAD_FILES_LIMIT)
+    files = get_available_log_files(SESSION_FACTORY(), COLLECTION, DIR_WORKING_LOGS, LOAD_FILES_LIMIT)
 
     for file_attrs in files:
         file_id, file_path, start_line = file_attrs
@@ -145,7 +145,8 @@ def main():
 
         if total_lines > 0:
             logging.info('Loading %s' % gunzipped_file_path)
-            update_log_file_status(LOG_FILE_DATABASE_STRING, COLLECTION, file_id, LOG_FILE_STATUS_LOADING)
+            update_log_file_status(SESSION_FACTORY(), COLLECTION, file_id, LOG_FILE_STATUS_LOADING)
+
             import_logs_params = generate_import_logs_params(gunzipped_file_path, summary_path_output, start_line)
             subprocess.call('python2 import_logs.py' + ' ' + import_logs_params, shell=True)
 

--- a/proc/load_logs.py
+++ b/proc/load_logs.py
@@ -157,13 +157,20 @@ def main():
 
             logging.info('Updating log_file_summary with %s' % summary_path_output)
             full_path_summary_output = os.path.join(DIR_SUMMARY, summary_path_output)
-            status = update_log_file_summary(LOG_FILE_DATABASE_STRING, full_path_summary_output, total_lines, file_id)
+            status = update_log_file_summary(SESSION_FACTORY(),
+                                             full_path_summary_output,
+                                             total_lines,
+                                             file_id,
+                                             DIR_RECOVERY,
+                                             matomo_status)
 
-            logging.info('Updating log_file for row %s' % file_id)
-            update_log_file_status(LOG_FILE_DATABASE_STRING, COLLECTION, file_id, status)
+            if status != CRITICAL_ERROR:
+                logging.info('Updating log_file for row %s' % file_id)
+                update_log_file_status(SESSION_FACTORY(), COLLECTION, file_id, status)
 
-            logging.info('Updating date_status')
-            update_date_status(LOG_FILE_DATABASE_STRING, COLLECTION)
+                logging.info('Updating date_status')
+                update_date_status(SESSION_FACTORY(), COLLECTION)
+
 
         logging.info('Removing files %s and %s' % (file_path, gunzipped_file_path))
         os.remove(file_path)

--- a/proc/load_logs.py
+++ b/proc/load_logs.py
@@ -148,7 +148,12 @@ def main():
             update_log_file_status(SESSION_FACTORY(), COLLECTION, file_id, LOG_FILE_STATUS_LOADING)
 
             import_logs_params = generate_import_logs_params(gunzipped_file_path, summary_path_output, start_line)
-            subprocess.call('python2 import_logs.py' + ' ' + import_logs_params, shell=True)
+
+            try:
+                subprocess.call('python2 import_logs.py' + ' ' + import_logs_params, shell=True)
+                matomo_status = MATOMO_STATUS_SUCCESS
+            except subprocess.CalledProcessError:
+                matomo_status = MATOMO_STATUS_ERROR
 
             logging.info('Updating log_file_summary with %s' % summary_path_output)
             full_path_summary_output = os.path.join(DIR_SUMMARY, summary_path_output)

--- a/proc/update_available_logs.py
+++ b/proc/update_available_logs.py
@@ -31,6 +31,8 @@ RETRY_DIFF_LINES = int(os.environ.get('RETRY_DIFF_LINES', '110000'))
 
 LOGGING_LEVEL = os.environ.get('LOGGING_LEVEL', 'INFO')
 
+ENGINE = create_engine(LOG_FILE_DATABASE_STRING)
+SESSION_FACTORY = sessionmaker(bind=ENGINE)
 
 def copy_available_log_files(database_uri, collection, dir_working_logs, copy_files_limit):
     current_files = os.listdir(dir_working_logs)

--- a/proc/update_available_logs.py
+++ b/proc/update_available_logs.py
@@ -21,10 +21,13 @@ from libs.lib_database import (
 DIR_USAGE_LOGS_1 = os.environ.get('DIR_USAGE_LOGS_1', '/app/usage-logs-1')
 DIR_USAGE_LOGS_2 = os.environ.get('DIR_USAGE_LOGS_2', '/app/usage-logs-2')
 DIR_WORKING_LOGS = os.environ.get('DIR_WORKING_LOGS', '/app/data/working')
+DIR_SUMMARY = os.environ.get('DIR_SUMMARY', '/app/data/summary')
+DIR_RECOVERY = os.path.join(DIR_SUMMARY, 'recovery')
 LOG_FILE_DATABASE_STRING = os.environ.get('LOG_FILE_DATABASE_STRING', 'mysql://user:pass@localhost:3306/matomo')
 
 COPY_FILES_LIMIT = int(os.environ.get('COPY_FILES_LIMIT', 10))
 COLLECTION = os.environ.get('COLLECTION', 'scl')
+RETRY_DIFF_LINES = int(os.environ.get('RETRY_DIFF_LINES', '110000'))
 
 LOGGING_LEVEL = os.environ.get('LOGGING_LEVEL', 'INFO')
 

--- a/proc/update_available_logs.py
+++ b/proc/update_available_logs.py
@@ -4,9 +4,18 @@ import logging
 import os
 import shutil
 
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 from libs.lib_file_name import add_gunzip_extension
 from libs.lib_status import LOG_FILE_STATUS_INVALID, LOG_FILE_STATUS_LOADED
-from libs.lib_database import update_available_log_files, update_date_status, get_recent_log_files
+from sqlalchemy.exc import OperationalError
+from libs.lib_database import (
+    update_available_log_files,
+    update_date_status,
+    get_recent_log_files,
+    update_log_file_status,
+    update_log_file_summary_with_recovery_data
+)
 
 
 DIR_USAGE_LOGS_1 = os.environ.get('DIR_USAGE_LOGS_1', '/app/usage-logs-1')

--- a/proc/update_available_logs.py
+++ b/proc/update_available_logs.py
@@ -128,14 +128,21 @@ def main():
         logging.info('Creating DIR_WORKING_LOGS=%s' % DIR_WORKING_LOGS)
         os.makedirs(DIR_WORKING_LOGS)
 
+    if not os.path.exists(DIR_RECOVERY):
+        logging.info('Creating DIR_RECOVERY=%s' % DIR_RECOVERY)
+        os.makedirs(DIR_RECOVERY)
+
+    logging.info('Checking for recovery data...')
+    check_and_fix_recovery_data()
+
     if 'update_log_file' in params.exec_mode:
         for dir_log in [DIR_USAGE_LOGS_1, DIR_USAGE_LOGS_2]:
             logging.info('Updating table log_file with possible new logs in %s' % dir_log)
-            update_available_log_files(LOG_FILE_DATABASE_STRING, dir_log, COLLECTION)
+            update_available_log_files(SESSION_FACTORY(), dir_log, COLLECTION)
 
     if 'copy_logs' in params.exec_mode:
-        copy_available_log_files(LOG_FILE_DATABASE_STRING, COLLECTION, DIR_WORKING_LOGS, COPY_FILES_LIMIT)
+        copy_available_log_files(SESSION_FACTORY(), COLLECTION, DIR_WORKING_LOGS, COPY_FILES_LIMIT)
 
     if 'date_status' in params.exec_mode:
         logging.info('Updating table date_status')
-        update_date_status(LOG_FILE_DATABASE_STRING, COLLECTION)
+        update_date_status(SESSION_FACTORY(), COLLECTION)


### PR DESCRIPTION
1. Adição de método para gravar em disco dados de recuperação;
2. Refatoração de todos os métodos para usar, de forma adequada, a fábrica de sessão;
3. Alteração de de Engine e SessionFactory para nível de script;
4. Adição de método para verificar a existência de conteúdo em diretório de recuperação;
5. Tratamento de erro de servidor Matomo estar indisponível.
