### PR TITLE
Atualiza extrator de arquivos de log de acesso da Venezuela

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 loaded
 Pipfile
 *.lock
+.venv

--- a/libs/lib_database.py
+++ b/libs/lib_database.py
@@ -74,7 +74,7 @@ def update_available_log_files(db_session, dir_usage_logs, collection):
                     lf.status = LOG_FILE_STATUS_QUEUE
                     lf.collection = collection
 
-                    if not is_valid_log(lf.full_path, lf.server, lf.date):
+                    if not is_valid_log(lf.collection, lf.full_path, lf.server, lf.date):
                         lf.status = LOG_FILE_STATUS_INVALID
                         logging.warning('LogFile row created, but will not be loaded due to unmet requirements: %s' % file)
                     else:

--- a/libs/lib_file_name.py
+++ b/libs/lib_file_name.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 import re
 import os
+import sys
 
 from libs.values import *
 
@@ -73,27 +74,35 @@ def _check_new_brasil(full_path, file_name):
 
 
 def _check_venezuela(full_path, file_name):
-    if FILE_VENEZUELA_CENTOS01_NAME in full_path:
-        if re.search(REGEX_VENEZUELA_STARTS_WITH_DATE, file_name):
-            return FILE_VENEZUELA_NAME_1
+    if FILE_VENEZUELA_APACHE_NAME in full_path:
+        if FILE_VENEZUELA_CENTOS01_NAME in full_path:
+            if re.search(REGEX_VENEZUELA_STARTS_WITH_DATE, file_name):
+                return FILE_VENEZUELA_NAME_1
 
-        elif re.search(REGEX_VENEZUELA_ENDS_WITH_DATE, file_name):
-            return FILE_VENEZUELA_NAME_2
+            elif re.search(REGEX_VENEZUELA_ENDS_WITH_DATE, file_name):
+                return FILE_VENEZUELA_NAME_3
 
-        elif re.search(REGEX_VENEZUELA_ENDS_WITH_DATE_NO_HIPHEN, file_name):
-            return FILE_VENEZUELA_NAME_3
-
-    elif FILE_VENEZUELA_CENTOS02_NAME in full_path:
-        if FILE_VENEZUELA_CENTOS02_ORG_VE_NAME in full_path:
-            if re.search(REGEX_VENEZUELA_ENDS_WITH_DATE, file_name):
+            elif re.search(REGEX_VENEZUELA_ENDS_WITH_DATE_NO_HIPHEN, file_name):
                 return FILE_VENEZUELA_NAME_4
 
-        elif FILE_VENEZUELA_CENTOS02_VARNISH_NAME in full_path:
-            return FILE_VENEZUELA_NAME_5
+        elif FILE_VENEZUELA_CENTOS02_NAME in full_path:
+            if FILE_VENEZUELA_CENTOS02_ORG_VE_NAME in full_path:
+                if re.search(REGEX_VENEZUELA_ENDS_WITH_DATE, file_name):
+                    return FILE_VENEZUELA_NAME_5
 
-    elif FILE_VENEZUELA_GENERIC_NAME in file_name:
-        if re.search(REGEX_VENEZUELA_STARTS_WITH_DATE, file_name):
-            return FILE_VENEZUELA_NAME_1
+            elif FILE_VENEZUELA_CENTOS02_VARNISH_NAME in full_path:
+                return FILE_VENEZUELA_NAME_6
+
+        elif FILE_VENEZUELA_GENERIC_NAME_1 in file_name:
+            if re.search(REGEX_VENEZUELA_STARTS_WITH_DATE, file_name):
+                return FILE_VENEZUELA_NAME_1
+
+        elif FILE_VENEZUELA_GENERIC_NAME_2 in file_name:
+            if re.search(REGEX_VENEZUELA_STARTS_WITH_DATE, file_name):
+                return FILE_VENEZUELA_NAME_2
+
+    elif FILE_VENEZUELA_HA_NAME in full_path:
+        return FILE_VENEZUELA_NAME_7
 
 
 def extract_log_server_name(full_path):

--- a/libs/lib_status.py
+++ b/libs/lib_status.py
@@ -1,7 +1,8 @@
 # coding=utf-8
 import datetime
 
-from libs.lib_file_name import extract_file_name
+from libs.lib_file_name import extract_file_name, INVALID_SERVERS
+
 
 DATE_STATUS_QUEUE = 0
 DATE_STATUS_PARTIAL = 1
@@ -59,18 +60,19 @@ def compute_date_status(logfile_status_list, collection):
     return DATE_STATUS_QUEUE
 
 
-def is_valid_log(log_file_full_path, log_file_server, log_file_date):
+def is_valid_log(collection, log_file_full_path, log_file_server, log_file_date):
     date = datetime.datetime.strptime(log_file_date, '%Y-%m-%d')
 
-    # Situação em que arquivo com prefixo varnishncsa contém IPs anônimos
-    if 'varnishncsa' in log_file_full_path:
-        if date > datetime.datetime.strptime('2020-04-29', '%Y-%m-%d'):
-            return False
+    if collection == 'scl':
+        # Situação em que arquivo com prefixo varnishncsa contém IPs anônimos
+        if 'varnishncsa' in log_file_full_path:
+            if date > datetime.datetime.strptime('2020-04-29', '%Y-%m-%d'):
+                return False
 
-    # Situação em que arquivo de servidor hiperion-apache contém IPs anônimos
-    if log_file_server == 'hiperion-apache':
-        if date > datetime.datetime.strptime('2020-04-29', '%Y-%m-%d'):
-            return False
+        # Situação em que arquivo de servidor hiperion-apache contém IPs anônimos
+        if log_file_server == 'hiperion-apache':
+            if date > datetime.datetime.strptime('2020-04-29', '%Y-%m-%d'):
+                return False
 
     if log_file_server == 'preprints':
         # Situação em que arquivo de servidor preprints contém apenas erros de acesso
@@ -85,5 +87,8 @@ def is_valid_log(log_file_full_path, log_file_server, log_file_date):
         # Situação em que não se trata de um arquivo com extensão .log.gz
         if not log_file_name.endswith('.log.gz'):
             return False
+
+    if collection == 'ven' and log_file_server in INVALID_SERVERS:
+        return False
 
     return True

--- a/libs/values.py
+++ b/libs/values.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 # Logs SciELO Brasil (site clássico)
 FILE_APACHE_NAME = 'apache'
 FILE_NODE03_NAME = 'node03'
@@ -21,19 +23,24 @@ FILE_DATAVERSE_NAME_1 = 'data1'
 FILE_DATAVERSE_NAME_2 = 'data2'
 
 # Logs SciELO Venezuela
+FILE_VENEZUELA_APACHE_NAME = 'apache'
+FILE_VENEZUELA_HA_NAME = 'logs-ha'
 FILE_VENEZUELA_CENTOS01_NAME = 'centos-2gb-nyc3-01'
 FILE_VENEZUELA_CENTOS02_NAME = 'centos-2gb-nyc3-02'
 FILE_VENEZUELA_CENTOS02_ORG_VE_NAME = 'scielo-org-ve'
 FILE_VENEZUELA_CENTOS02_VARNISH_NAME = 'varnish-aws'
-FILE_VENEZUELA_GENERIC_NAME = '+ve-scielo-org-access'
+FILE_VENEZUELA_GENERIC_NAME_1 = 've-scielo-org-access'
+FILE_VENEZUELA_GENERIC_NAME_2 = 've-scielo-org'
 REGEX_VENEZUELA_ENDS_WITH_DATE = r'scielo-org-ve.log-\d{4}-\d{2}-\d{2}\.gz'
 REGEX_VENEZUELA_ENDS_WITH_DATE_NO_HIPHEN = r'scielo-org-ve.log-\d{4}\d{2}\d{2}\.gz'
-REGEX_VENEZUELA_STARTS_WITH_DATE = r'\d{4}-\d{2}-\d{2}\+ve-scielo-org-access\.log\.gz'
+REGEX_VENEZUELA_STARTS_WITH_DATE = r'^\d{4}-\d{2}-\d{2}.*ve-scielo-org.*\.log\.gz'
 FILE_VENEZUELA_NAME_1 = 'ven1'
 FILE_VENEZUELA_NAME_2 = 'ven2'
 FILE_VENEZUELA_NAME_3 = 'ven3'
 FILE_VENEZUELA_NAME_4 = 'ven4'
 FILE_VENEZUELA_NAME_5 = 'ven5'
+FILE_VENEZUELA_NAME_6 = 'ven6'
+FILE_VENEZUELA_NAME_7 = 'ven7'
 
 # Logs SciELO de outras coleções
 PARTIAL_FILE_NAME_TO_SERVER = {
@@ -59,3 +66,13 @@ PARTIAL_FILE_NAME_TO_SERVER = {
 
 # Logs de coleção não detectada
 FILE_INFO_UNDEFINED = ''
+
+# Servidores invalidados
+INVALID_SERVERS = {
+    'ven1',
+    'ven2',
+    'ven3',
+    'ven4',
+    'ven5',
+    'ven6'
+}


### PR DESCRIPTION
Um novo diretório foi adicionado ao ponto de montagem /logs-venezuela.
Este PR adequa o código-fonte para melhor entender quais são os arquivos que devem ser carregados (em relação à coleção Venzuela).