### PR TITLE
Atualiza forma como um dia é considerado carregado (coleção scl)

### DIFF
--- a/libs/lib_database.py
+++ b/libs/lib_database.py
@@ -116,7 +116,7 @@ def update_date_status(db_session, collection):
             lfdate_to_status_files[lf.date].append(lf.status)
 
         for key in lfdate_to_status_files:
-            new_status = compute_date_status(lfdate_to_status_files[key], collection)
+            new_status = compute_date_status(lfdate_to_status_files[key], collection, date=key)
 
             try:
                 existing_date_status = db_session.query(DateStatus).filter(and_(DateStatus.collection == collection,

--- a/libs/lib_status.py
+++ b/libs/lib_status.py
@@ -45,7 +45,7 @@ COLLECTION_TO_EXPECTED_DAILY_STATUS_SUM = {
 DEFAULT_STATUS_SUM = 2
 
 
-def compute_date_status(logfile_status_list, collection):
+def compute_date_status(logfile_status_list, collection, date=None):
     status_sum = 0
     for s in logfile_status_list:
         if s == LOG_FILE_STATUS_LOADED:

--- a/libs/lib_status.py
+++ b/libs/lib_status.py
@@ -33,7 +33,9 @@ COLLECTION_TO_EXPECTED_DAILY_STATUS_SUM = {
     'pry': 1,
     'psi': 1,
     'rve': 1,
-    'scl': 2,
+    'scl': {
+        'before_2021_05_25': 2,
+        'after_2021_05_25': 1},
     'ssp': 2,
     'sss': 1,
     'sza': 1,

--- a/libs/lib_status.py
+++ b/libs/lib_status.py
@@ -53,7 +53,13 @@ def compute_date_status(logfile_status_list, collection, date=None):
         if s == LOG_FILE_STATUS_LOADED:
             status_sum += 1
 
-    expected_status_sum = COLLECTION_TO_EXPECTED_DAILY_STATUS_SUM.get(collection, DEFAULT_STATUS_SUM)
+    if collection == 'scl':
+        if date > datetime.datetime.strptime('2021-05-25', '%Y-%m-%d').date():
+            expected_status_sum = COLLECTION_TO_EXPECTED_DAILY_STATUS_SUM.get(collection).get('after_2021_05_25')
+        else:
+            expected_status_sum = COLLECTION_TO_EXPECTED_DAILY_STATUS_SUM.get(collection).get('before_2021_05_25')
+    else:
+        expected_status_sum = COLLECTION_TO_EXPECTED_DAILY_STATUS_SUM.get(collection, DEFAULT_STATUS_SUM)
 
     if status_sum == expected_status_sum:
         return DATE_STATUS_LOADED

--- a/proc/update_available_logs.py
+++ b/proc/update_available_logs.py
@@ -113,10 +113,13 @@ def main():
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
-        '-m', '--execution_mode',
-        dest='exec_mode',
-        default=['update_log_file', 'copy_logs', 'date_status'],
-        help='Modo de execução'
+        '--execution_mode',
+        action='append',
+        help='Modos de execução',
+        choices=[
+            'update_table_log_file',
+            'update_table_date_status',
+            'copy_logs']
     )
 
     params = parser.parse_args()
@@ -136,14 +139,14 @@ def main():
     logging.info('Checking for recovery data...')
     check_and_fix_recovery_data()
 
-    if 'update_log_file' in params.exec_mode:
+    if 'update_table_log_file' in params.execution_mode:
         for dir_log in [DIR_USAGE_LOGS_1, DIR_USAGE_LOGS_2]:
             logging.info('Updating table log_file with possible new logs in %s' % dir_log)
             update_available_log_files(SESSION_FACTORY(), dir_log, COLLECTION)
 
-    if 'copy_logs' in params.exec_mode:
+    if 'copy_logs' in params.execution_mode:
         copy_available_log_files(SESSION_FACTORY(), COLLECTION, DIR_WORKING_LOGS, COPY_FILES_LIMIT)
 
-    if 'date_status' in params.exec_mode:
+    if 'update_table_date_status' in params.execution_mode:
         logging.info('Updating table date_status')
         update_date_status(SESSION_FACTORY(), COLLECTION)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
 
 setup(
     name="scielo-matomo-manager",
-    version='0.1',
+    version='0.1.1',
     description="The SciELO Matomo Manager",
     author="SciELO",
     author_email="scielo-dev@googlegroups.com",

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@
 from setuptools import setup, find_packages
 
 install_requires = [
-    'sqlalchemy==1.3.22',
-    'mysqlclient==1.4.6',
-    'python-magic==0.4.22',
+    'sqlalchemy',
+    'mysqlclient',
+    'python-magic',
 ]
 
 


### PR DESCRIPTION
A partir da data 26/05/2021 a coleção Brasil do site antigo passou a ter apenas um arquivo de log de acesso válido por dia. Essa característica foi incorporada na aplicação a partir deste PR, que, também realiza o seguinte:

- Adequa método que decide de dia foi carregado por completo
- Melhora forma de passar parâmetros de linha de comando
