### PR TITLE
Adiciona suporte à coleção Cuba

### DIFF
--- a/libs/lib_file_name.py
+++ b/libs/lib_file_name.py
@@ -55,6 +55,14 @@ def _check_ratchet(full_path, file_name, collection):
             if collection in server_prefix:
                 results.append(''.join(PARTIAL_FILE_NAME_TO_SERVER[k]))
 
+    if len(results) == 0:
+        for k in PARTIAL_DIR_TO_SERVER:
+            if k in full_path:
+                server_prefix, server_number = PARTIAL_DIR_TO_SERVER[k]
+
+                if collection in server_prefix:
+                    results.append(''.join(PARTIAL_DIR_TO_SERVER[k]))
+
     if len(results) == 1:
         return results[0]
 

--- a/libs/values.py
+++ b/libs/values.py
@@ -48,6 +48,10 @@ FILE_VENEZUELA_NAME_6 = 'ven6'
 FILE_VENEZUELA_NAME_7 = 'ven7'
 
 # Logs SciELO de outras coleções
+PARTIAL_DIR_TO_SERVER = {
+    'scielo.cu': ('cub', ''),
+}
+
 PARTIAL_FILE_NAME_TO_SERVER = {
     'scielo.ar.': ('arg', ''),
     'scielo.bo.': ('bol', ''),

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
 
 setup(
     name="scielo-matomo-manager",
-    version='0.3.3',
+    version='0.3.4',
     description="The SciELO Log Discover",
     author="SciELO",
     author_email="scielo-dev@googlegroups.com",


### PR DESCRIPTION
Este PR adiciona suporte à identificação de arquivos de log da coleção Cuba. Trata-se de um fix para considerar o subdiretório como uma forma de associar arquivos à coleção. Antes, o sistema olhava apenas para o nome.

Isso se fez necessário porque os arquivos dessa coleção não contêm o termo scielo.cu.log.gz, como o sistema esperava.

Exemplos de arquivos que passaram a pertencem a coleção Cuba (do ponto de vista da tabela control_log_file):

- /logs-ratchet/scielo.cu/scielo-access.log-20211114.gz
- /logs-ratchet/scielo.cu/scielo-access.log-20211115.gz
- /logs-ratchet/scielo.cu/scielo-access.log-20211116.gz
- /logs-ratchet/scielo.cu/scielo-access.log-20211117.gz
- /logs-ratchet/scielo.cu/scielo-access.log-20211118.gz

Este é um PR emergencial, já que esta aplicação será descontinuada em lugar de um projeto Wagtail.