### PR TITLE
Clean R5 hit files and bump version to 0.4.5

### DIFF
--- a/proc/clean_data.py
+++ b/proc/clean_data.py
@@ -52,7 +52,7 @@ def clean_pretables(dir_zip_pretables, pretables_to_remove):
         os.remove(pt)
 
 
-def clean_r5_metrics(r5_files_to_remove):
+def clean_r5_files(r5_files_to_remove):
     for r5f in r5_files_to_remove:
         logging.info('Removing file %s' % r5f)
         os.remove(r5f)
@@ -89,6 +89,12 @@ def main():
     )
 
     parser.add_argument(
+        '--dir_r5_hits',
+        help='Diretório com arquivos de hits r5',
+        required=True,
+    )
+
+    parser.add_argument(
         '--dir_zip_pretables',
         help='Diretório com arquivos compactados de pré-tabelas',
         required=True,
@@ -102,6 +108,7 @@ def main():
     for d in [
         params.dir_pretables,
         params.dir_r5_metrics,
+        params.dir_r5_hits,
         params.dir_zip_pretables
     ]:
         check_dir(d)
@@ -109,5 +116,20 @@ def main():
     pretables_to_remove = get_files_to_remove(params.collection, params.dir_pretables, SESSION_FACTORY(), extension='tsv')
     clean_pretables(params.dir_zip_pretables, pretables_to_remove)
 
-    r5_files_to_remove = get_files_to_remove(params.collection, params.dir_r5_metrics, SESSION_FACTORY(), extension='csv', prefix='r5-metrics-')
-    clean_r5_metrics(r5_files_to_remove)
+    r5_metrics_files_to_remove = get_files_to_remove(
+        params.collection,
+        params.dir_r5_metrics,
+        SESSION_FACTORY(),
+        extension='csv',
+        prefix='r5-metrics-',
+    )
+    clean_r5_files(r5_metrics_files_to_remove)
+
+    r5_hits_files_to_remove = get_files_to_remove(
+        params.collection,
+        params.dir_r5_hits,
+        SESSION_FACTORY(),
+        extension='csv',
+        prefix='r5-hits-',
+    )
+    clean_r5_files(r5_hits_files_to_remove)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
 
 setup(
     name="scielo-matomo-manager",
-    version='0.4.4',
+    version='0.4.5',
     description="The SciELO Log Discover",
     author="SciELO",
     author_email="scielo-dev@googlegroups.com",


### PR DESCRIPTION
This pull request adds support for cleaning up a new type of R5 file ("hits") in the data processing script, along with some minor refactoring and a version bump. The main changes are the introduction of a new command-line argument and logic to handle "r5-hits" files, as well as some renaming for clarity.

**Support for cleaning new R5 file type:**

* Added a new command-line argument `--dir_r5_hits` to specify the directory containing "r5-hits" files.
* Updated the cleanup logic in `main()` to find and remove "r5-hits" files, using the new directory and file prefix.

**Refactoring and naming improvements:**

* Renamed the function `clean_r5_metrics` to `clean_r5_files` to generalize its purpose for both metrics and hits files.

**Version update:**

* Bumped the project version from `0.4.4` to `0.4.5` in `setup.py`.